### PR TITLE
introduces request, andThen, sendRequest, map, map2, map3

### DIFF
--- a/Porter.elm
+++ b/Porter.elm
@@ -82,6 +82,19 @@ type Msg req res msg
     = SendWithNextId (res -> msg) req
     | Receive Encode.Value
 
+type Request req res msg = Request req (List (res -> req)) (res -> msg)
+type PartialRequest req res = PartialRequest req (List (res -> req))
+
+request req = PartialRequest req []
+
+andThen (PartialRequest initial_req reqfuns) reqfun = PartialRequest initial_req (reqfun :: reqfuns)
+
+sendRequest : Config req res msg -> (PartialRequest req res) -> (res -> msg) -> Cmd msg
+sendRequest config (PartialRequest req reqfuns) response_handler =
+    let
+        request = Request req (List.reverse reqfuns) response_handler
+    in
+        Debug.crash "Not Implemented"
 
 {-| Subscribe to messages from ports.
 -}

--- a/Porter.elm
+++ b/Porter.elm
@@ -132,15 +132,15 @@ request req =
 Run a second one right away when the first returns using its result in the request.
 -}
 andThen : (res -> Request req res) -> Request req res -> Request req res
-andThen reqfun (Request initial_req reqfuns) =
-    Request initial_req (reqfun :: reqfuns)
+andThen reqfun (Request initialReq reqfuns) =
+    Request initialReq (reqfun :: reqfuns)
 
 
 {-| Sends a request earlier started using `request`.
 -}
 send: Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
-send config response_handler (Request req reqfuns) =
-    runSendRequest config (RequestWithHandler req (List.reverse reqfuns) response_handler)
+send config responseHandler (Request req reqfuns) =
+    runSendRequest config (RequestWithHandler req (List.reverse reqfuns) responseHandler)
 
 
 {-| Internal function that performs the specified request as a command.

--- a/Porter.elm
+++ b/Porter.elm
@@ -106,7 +106,7 @@ type RequestWithHandler req res msg
 
 
 {-| Opaque type of a 'request'. Use the `request` function to create one,
-chain them using `andThen` and finally send it using `sendRequest`.
+chain them using `andThen` and finally send it using `send`.
 -}
 type Request req res
     = Request req (List (res -> Request req res))
@@ -120,7 +120,7 @@ subscriptions config =
         |> Sub.map config.porterMsg
 
 
-{-| Starts a request that can be sent at a later time using `sendRequest`,
+{-| Starts a request that can be sent at a later time using `send`,
 and that can be combined using `andThen`.
 -}
 request : req -> Request req res

--- a/Porter.elm
+++ b/Porter.elm
@@ -10,10 +10,6 @@ module Porter
         , send
         , request
         , andThen
-        , sendRequest
-        , map
-        , map2
-        , map3
         )
 
 {-| Port message manager to emulate a request-response style communication through ports, a'la `Http.send ResponseHandler request`.
@@ -28,17 +24,14 @@ module Porter
 
 @docs Model, Msg, init, update, subscriptions
 
-
 # Send messages
 
-@docs send
-
-
-# Build a complex chain of requests and finally send it
-
 @docs Request
+@docs request, andThen, send
 
-@docs request, andThen, sendRequest, map, map2, map3
+
+
+
 
 -}
 
@@ -127,13 +120,6 @@ subscriptions config =
         |> Sub.map config.porterMsg
 
 
-{-| Initiate a message send.
--}
-send : Config req res msg -> (res -> msg) -> req -> Cmd msg
-send config responseHandler request =
-    runSendRequest config (RequestWithHandler request [] responseHandler)
-
-
 {-| Starts a request that can be sent at a later time using `sendRequest`,
 and that can be combined using `andThen`.
 -}
@@ -150,36 +136,10 @@ andThen reqfun (Request initial_req reqfuns) =
     Request initial_req (reqfun :: reqfuns)
 
 
-{-| Transforms a request
--}
-map : (res -> req) -> Request req res -> Request req res
-map func reqA =
-    reqA
-        |> andThen (\a -> request (func a))
-
-
-{-| Run a request using the results of two earlier requests.
--}
-map2 : (res -> res -> req) -> Request req res -> Request req res -> Request req res
-map2 func reqA reqB =
-    reqA
-        |> andThen (\a -> reqB
-        |> andThen (\b -> request (func a b)))
-
-
-{-| -}
-map3 : (res -> res -> res -> req) -> Request req res -> Request req res -> Request req res -> Request req res
-map3 func reqA reqB reqC =
-    reqA
-      |> andThen (\a -> reqB
-      |> andThen (\b -> reqC
-      |> andThen (\c -> request (func a b c))))
-
-
 {-| Sends a request earlier started using `request`.
 -}
-sendRequest : Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
-sendRequest config response_handler (Request req reqfuns) =
+send: Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
+send config response_handler (Request req reqfuns) =
     runSendRequest config (RequestWithHandler req (List.reverse reqfuns) response_handler)
 
 

--- a/Porter.elm
+++ b/Porter.elm
@@ -9,6 +9,9 @@ module Porter exposing
     , request
     , andThen
     , sendRequest
+    , map
+    , map2
+    , map3
     )
 
 {-| Port message manager to emulate a request-response style communication through ports, a'la `Http.send ResponseHandler request`.
@@ -30,7 +33,7 @@ module Porter exposing
 
 # Build a complex chain of requests and finally send it
 
-@docs request, andThen, sendRequest
+@docs request, andThen, sendRequest, map, map2, map3
 
 -}
 
@@ -135,14 +138,29 @@ request req = Request req []
 andThen : (res -> Request req res) -> Request req res -> Request req res
 andThen reqfun (Request initial_req reqfuns) = Request initial_req (reqfun :: reqfuns)
 
+{-| Transforms a request
+
+-}
+map : (res -> req) -> Request req res -> Request req res
 map func reqA =
     reqA
         |> andThen (\a -> request (func a))
 
+{-| Run a request using the results of two earlier requests.
+ -}
+map2 : (res -> res -> req) -> Request req res -> Request req res -> Request req res
 map2 func reqA reqB =
   reqA
       |> andThen (\a -> reqB
       |> andThen (\b -> request (func a b)))
+
+{-|-}
+map3 : (res -> res -> res -> req) -> Request req res -> Request req res -> Request req res -> Request req res
+map3 func reqA reqB reqC =
+  reqA
+    |> andThen (\a -> reqB
+    |> andThen (\b -> reqC
+    |> andThen (\c -> request (func a b c))))
 
 {-| Sends a request earlier started using `request`.
 -}

--- a/Porter.elm
+++ b/Porter.elm
@@ -260,9 +260,5 @@ handleResponse config (Model model) id res (FullRequest msg mappers finalRespons
                 extractMappers (Request _ req_mappers) = req_mappers
             in
           ( Model { model | handlers = Dict.remove id model.handlers }
-          -- , Task.succeed (FullRequest (mapper res) mappers finalResponseHandler)
-          --     |> Task.map SendWithNextId
-          --     |> Task.perform config.porterMsg
-                -- , sendRequest config request finalResponseHandler
-          , runSendRequest config (FullRequest (extractMsg request) (extractMappers request) finalResponseHandler)
+          , runSendRequest config (FullRequest (extractMsg request) ((extractMappers request) ++ mappers) finalResponseHandler)
           )

--- a/Porter.elm
+++ b/Porter.elm
@@ -3,6 +3,7 @@ module Porter
         ( Model
         , Config
         , Msg
+        , Request
         , subscriptions
         , init
         , update
@@ -34,6 +35,8 @@ module Porter
 
 
 # Build a complex chain of requests and finally send it
+
+@docs Request
 
 @docs request, andThen, sendRequest, map, map2, map3
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ If you want to perform multiple requests where some of these request depend on r
 
 ```elm
 Porter.request ("Reverse me too!")
-  |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " The Quick Brown Fox!"))
-  |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " A man a plan a canal: panama"))
+  |> Porter.andThen (\reversedStr -> Porter.request (reversedStr ++ " The Quick Brown Fox!"))
+  |> Porter.andThen (\reversedStr -> Porter.request (reversedStr ++ " A man a plan a canal: panama"))
   |> Porter.sendRequest porterConfig Receive
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ init =
       , response = ""
       }
       -- Send a request through porter, specifying the response handler directly
-    , Porter.send porterConfig Receive "Reverse me!"
+      , Porter.send porterConfig Receive (Porter.request "Reverse me!")
     )
 
 
@@ -154,4 +154,19 @@ Porter.request ("Reverse me too!")
   |> Porter.sendRequest porterConfig Receive
 ```
 
-`Porter.map`, `Porter.map2` and `Porter.map3` are also available.
+
+## Changelog
+
+###  2.0
+
+- The `Porter.Config` type now has a `porterMsg`-field.
+- Signature of `Porter.send` was changed: 
+  - It now takes the `porterConfig` as argument, meaning (in combination with the previous change) that `Cmd.map`ping the result to your Msg type is no longer necessary because this is handled for you.
+  - Requests are now constructed using `Porter.request` and can be chained using `Porter.andThen` before passing them off to `Porter.send`. 
+
+So: Where in Version 1 you'd use `Porter.send responseHandler request`, you'd now use `Porter.send porterConfig responseHandler (Porter.request request)`.
+
+
+### 1.0
+
+First stable release

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ porterConfig =
     -- Porter works with a single Request and Response data types. They can both be anything, as long as you supply decoders :)
     , encodeRequest = Encode.string
     , decodeResponse = Decode.string
+    -- Porter uses a message added to your Msg type for its internal communications (See `type Msg` below)
+    , porterMsg = PorterMsg
     }
 
 
@@ -59,7 +61,7 @@ init =
       , response = ""
       }
       -- Send a request through porter, specifying the response handler directly
-    , Porter.send Receive "Reverse me!" |> Cmd.map PorterMsg
+    , Porter.send porterConfig Receive "Reverse me!"
     )
 
 
@@ -96,7 +98,7 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Porter.subscriptions porterConfig |> Sub.map PorterMsg
+    Porter.subscriptions porterConfig
 
 
 

--- a/README.md
+++ b/README.md
@@ -142,3 +142,16 @@ app.ports.outgoing.subscribe(msgWithId => {
   })
 })
 ```
+
+## Chaining Requests
+
+If you want to perform multiple requests where some of these request depend on responses from other requests, you can use `Porter.request` in combination with `Porter.andThen` and `Porter.sendRequest`.
+
+```elm
+Porter.request ("Reverse me too!")
+  |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " The Quick Brown Fox!"))
+  |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " A man a plan a canal: panama"))
+  |> Porter.sendRequest porterConfig Receive
+```
+
+`Porter.map`, `Porter.map2` and `Porter.map3` are also available.

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -35,6 +35,7 @@ porterConfig =
 type alias Model =
     { porter : Porter.Model String String Msg
     , response : String
+    , advanced_response : String
     }
 
 
@@ -42,14 +43,20 @@ init : ( Model, Cmd Msg )
 init =
     ( { porter = Porter.init
       , response = ""
+      , advanced_response = ""
       }
-      -- Send a request through porter, specifying the response handler directly
-    -- , Porter.send porterConfig Receive "Reverse me!"
-          ,
-          Porter.request ("Reverse me!")
-          |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " The Quick Brown Fox!")
-          |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " A man a plan a canal: panama")
-          |> Porter.sendRequest porterConfig Receive
+    ,
+        Cmd.batch
+            [
+              -- Send a request through porter, specifying the response handler directly
+              Porter.send porterConfig Receive "Reverse me!"
+
+              -- Or send multiple requests one after the other:
+              , Porter.request ("Reverse me too!")
+                |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " The Quick Brown Fox!")
+                |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " A man a plan a canal: panama")
+                |> Porter.sendRequest porterConfig Receive2
+            ]
     )
 
 
@@ -60,6 +67,7 @@ init =
 type Msg
     = PorterMsg (Porter.Msg String String Msg)
     | Receive String
+    | Receive2 String
 
 
 
@@ -78,6 +86,8 @@ update msg model =
 
         Receive response ->
             ( { model | response = response }, Cmd.none )
+        Receive2 response ->
+            ( { model | advanced_response = response }, Cmd.none )
 
 
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -23,6 +23,7 @@ porterConfig =
     -- Porter works with a single Request and Response data types. They can both be anything, as long as you supply decoders :)
     , encodeRequest = Encode.string
     , decodeResponse = Decode.string
+    , porterMsg = PorterMsg
     }
 
 
@@ -42,7 +43,7 @@ init =
       , response = ""
       }
       -- Send a request through porter, specifying the response handler directly
-    , Porter.send Receive "Reverse me!" |> Cmd.map PorterMsg
+    , Porter.send porterConfig Receive "Reverse me!"
     )
 
 
@@ -79,7 +80,7 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Porter.subscriptions porterConfig |> Sub.map PorterMsg
+    Porter.subscriptions porterConfig
 
 
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -23,6 +23,7 @@ porterConfig =
     -- Porter works with a single Request and Response data types. They can both be anything, as long as you supply decoders :)
     , encodeRequest = Encode.string
     , decodeResponse = Decode.string
+    -- Porter uses a message added to your Msg type for its internal communications (See `type Msg` below)
     , porterMsg = PorterMsg
     }
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -36,7 +36,7 @@ porterConfig =
 type alias Model =
     { porter : Porter.Model String String Msg
     , response : String
-    , advanced_response : String
+    , advancedResponse : String
     }
 
 
@@ -44,7 +44,7 @@ init : ( Model, Cmd Msg )
 init =
     ( { porter = Porter.init
       , response = ""
-      , advanced_response = ""
+      , advancedResponse = ""
       }
     , Cmd.batch
         [ -- Send a request through porter, specifying the response handler directly
@@ -52,9 +52,9 @@ init =
 
         -- Or send multiple requests one after the other:
         , Porter.request ("Reverse me too!")
-            |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " The Quick Brown Fox!"))
-            |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " A man a plan a canal: panama"))
-            |> Porter.sendRequest porterConfig Receive2
+            |> Porter.andThen (\reversedStr -> Porter.request (reversedStr ++ " The Quick Brown Fox!"))
+            |> Porter.andThen (\reversedStr -> Porter.request (reversedStr ++ " A man a plan a canal: panama"))
+            |> Porter.sendRequest porterConfig ReceiveAdvanced
         ]
     )
 
@@ -66,7 +66,7 @@ init =
 type Msg
     = PorterMsg (Porter.Msg String String Msg)
     | Receive String
-    | Receive2 String
+    | ReceiveAdvanced String
 
 
 
@@ -86,8 +86,8 @@ update msg model =
         Receive response ->
             ( { model | response = response }, Cmd.none )
 
-        Receive2 response ->
-            ( { model | advanced_response = response }, Cmd.none )
+        ReceiveAdvanced response ->
+            ( { model | advancedResponse = response }, Cmd.none )
 
 
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -23,6 +23,7 @@ porterConfig =
     -- Porter works with a single Request and Response data types. They can both be anything, as long as you supply decoders :)
     , encodeRequest = Encode.string
     , decodeResponse = Decode.string
+
     -- Porter uses a message added to your Msg type for its internal communications (See `type Msg` below)
     , porterMsg = PorterMsg
     }
@@ -45,18 +46,16 @@ init =
       , response = ""
       , advanced_response = ""
       }
-    ,
-        Cmd.batch
-            [
-              -- Send a request through porter, specifying the response handler directly
-              Porter.send porterConfig Receive "Reverse me!"
+    , Cmd.batch
+        [ -- Send a request through porter, specifying the response handler directly
+          Porter.send porterConfig Receive "Reverse me!"
 
-              -- Or send multiple requests one after the other:
-              , Porter.request ("Reverse me too!")
-                |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " The Quick Brown Fox!"))
-                |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " A man a plan a canal: panama"))
-                |> Porter.sendRequest porterConfig Receive2
-            ]
+        -- Or send multiple requests one after the other:
+        , Porter.request ("Reverse me too!")
+            |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " The Quick Brown Fox!"))
+            |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " A man a plan a canal: panama"))
+            |> Porter.sendRequest porterConfig Receive2
+        ]
     )
 
 
@@ -86,6 +85,7 @@ update msg model =
 
         Receive response ->
             ( { model | response = response }, Cmd.none )
+
         Receive2 response ->
             ( { model | advanced_response = response }, Cmd.none )
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -47,8 +47,8 @@ init =
     -- , Porter.send porterConfig Receive "Reverse me!"
           ,
           Porter.request ("Reverse me!")
-          |> Porter.andThen (\reversed_str -> reversed_str ++ " The Quick Brown Fox!")
-          |> Porter.andThen (\reversed_str -> reversed_str ++ " A man a plan a canal: panama")
+          |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " The Quick Brown Fox!")
+          |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " A man a plan a canal: panama")
           |> Porter.sendRequest porterConfig Receive
     )
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -53,8 +53,8 @@ init =
 
               -- Or send multiple requests one after the other:
               , Porter.request ("Reverse me too!")
-                |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " The Quick Brown Fox!")
-                |> Porter.andThen (\reversed_str -> Porter.request <| reversed_str ++ " A man a plan a canal: panama")
+                |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " The Quick Brown Fox!"))
+                |> Porter.andThen (\reversed_str -> Porter.request (reversed_str ++ " A man a plan a canal: panama"))
                 |> Porter.sendRequest porterConfig Receive2
             ]
     )

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -48,13 +48,13 @@ init =
       }
     , Cmd.batch
         [ -- Send a request through porter, specifying the response handler directly
-          Porter.send porterConfig Receive "Reverse me!"
+          Porter.send porterConfig Receive (Porter.request "Reverse me!")
 
         -- Or send multiple requests one after the other:
         , Porter.request ("Reverse me too!")
             |> Porter.andThen (\reversedStr -> Porter.request (reversedStr ++ " The Quick Brown Fox!"))
             |> Porter.andThen (\reversedStr -> Porter.request (reversedStr ++ " A man a plan a canal: panama"))
-            |> Porter.sendRequest porterConfig ReceiveAdvanced
+            |> Porter.send porterConfig ReceiveAdvanced
         ]
     )
 

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -44,7 +44,12 @@ init =
       , response = ""
       }
       -- Send a request through porter, specifying the response handler directly
-    , Porter.send porterConfig Receive "Reverse me!"
+    -- , Porter.send porterConfig Receive "Reverse me!"
+          ,
+          Porter.request ("Reverse me!")
+          |> Porter.andThen (\reversed_str -> reversed_str ++ " The Quick Brown Fox!")
+          |> Porter.andThen (\reversed_str -> reversed_str ++ " A man a plan a canal: panama")
+          |> Porter.sendRequest porterConfig Receive
     )
 
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,16 +1,19 @@
-<body>
-<script src="/_compile/Example.elm"></script>
-<script>
-  const app = Elm.Example.fullscreen()
-  app.ports.outgoing.subscribe(msgWithId => {
-    const id = msgWithId.id
-    const request = msgWithId.msg
-    const response = request.split("").reverse().join("")
-    // Simply include the same `id` and the response under the `msg` key.
-    app.ports.incoming.send({
-      id: id,
-      msg: response
-    })
-  })
-</script>
-</body>
+<!DOCTYPE html/>
+<html>
+    <body>
+        <script src="/_compile/Example.elm"></script>
+        <script>
+         const app = Elm.Example.fullscreen()
+         app.ports.outgoing.subscribe(msgWithId => {
+             const id = msgWithId.id
+             const request = msgWithId.msg
+             const response = request.split("").reverse().join("")
+             // Simply include the same `id` and the response under the `msg` key.
+             app.ports.incoming.send({
+                 id: id,
+                 msg: response
+             })
+         })
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
- [x] Create a `Request` type
- [x] Create an internal `FullRequest` type, which is a request that has received a final handler that can turn the result back to the user's  `msg` type. _Naming might be improved?_
- [x] Add `request` to create an instance of the `Request` type.
- [x] Add `andThen` to combine two `Request` types together in a monadic fashion.
- [x] ~~~add trivial ('free') implementations of `map`, `map2` and `map3` based on `request` and `andThen`.~~~
- [x] Alter the dispatching of requests such that requests with multiple parts are automatically resolved.
- [x] Documentation of the former.
- [x] Updated example code.
- [x] Rename `sendRequest` to `send` (and replace the current `send` in the code and in the examples).
- [x] Exposes `Request` type signature (but not its constructors).
- [x] `map`, `map2`, `map3` were removed again, awaiting a better method for implementation. 
- [x] Adds Changelog for version 2.0 to README.

Fixes #4 

_(Note, this PR contains the changes of PR #6  as well, because the alteration in the return type of `update` makes it a lot easier to write its iterative procedure. Review (and hopefully merge) that one first.)_

This PR probably can be refactored further to make the code changes more readable; I am eager for your feedback!