### PR TITLE
Porter.Multi

### DIFF
--- a/Porter.elm
+++ b/Porter.elm
@@ -40,6 +40,8 @@ import Task
 import Json.Encode as Encode
 import Json.Decode as Decode
 
+import Porter.Internals exposing (RequestWithHandler(..), Request(..), MultiRequest(..), Msg(..))
+
 
 type alias MsgId =
     Int
@@ -61,14 +63,14 @@ type Model req res msg
   - the message that porter will use for its internal communications
 
 -}
-type alias Config req res msg =
-    { outgoingPort : Encode.Value -> Cmd msg
-    , incomingPort : (Encode.Value -> Msg req res msg) -> Sub (Msg req res msg)
-    , encodeRequest : req -> Encode.Value
-    , decodeResponse : Decode.Decoder res
-    , porterMsg : Msg req res msg -> msg
-    }
-
+type alias Config req res msg = Porter.Internals.Config req res msg
+-- type alias Config req res msg =
+--     { outgoingPort : Encode.Value -> Cmd msg
+--     , incomingPort : (Encode.Value -> Msg req res msg) -> Sub (Msg req res msg)
+--     , encodeRequest : req -> Encode.Value
+--     , decodeResponse : Decode.Decoder res
+--     , porterMsg : Msg req res msg -> msg
+--     }
 
 {-| Initialize model.
 -}
@@ -94,22 +96,26 @@ encode encodeReq id msg =
 
 {-| Module messages.
 -}
-type Msg req res msg
-    = SendWithNextId (RequestWithHandler req res msg)
-    | Receive Encode.Value
+type alias Msg req res msg = Porter.Internals.Msg req res msg
+-- type Msg req res msg
+--     = SendWithNextId (RequestWithHandler req res msg)
+--     | Receive Encode.Value
+--     | ResolveChain (MultiRequest req res msg)
 
 
 {-| Internal type used by requests that have a response handler.
 -}
-type RequestWithHandler req res msg
-    = RequestWithHandler req (List (res -> Request req res)) (res -> msg)
+type alias RequestWithHandler req res msg = Porter.Internals.RequestWithHandler req res msg
+-- type RequestWithHandler req res msg
+--     = RequestWithHandler req (List (res -> Request req res)) (res -> msg)
 
 
 {-| Opaque type of a 'request'. Use the `request` function to create one,
 chain them using `andThen` and finally send it using `send`.
 -}
-type Request req res
-    = Request req (List (res -> Request req res))
+type alias Request req res = Porter.Internals.Request req res
+-- type Request req res
+--     = Request req (List (res -> Request req res))
 
 
 {-| Subscribe to messages from ports.
@@ -138,19 +144,24 @@ andThen reqfun (Request initialReq reqfuns) =
 
 {-| Sends a request earlier started using `request`.
 -}
+
 send: Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
-send config responseHandler (Request req reqfuns) =
-    runSendRequest config (RequestWithHandler req (List.reverse reqfuns) responseHandler)
+send config responseHandler request =
+    Porter.Internals.send config responseHandler request
+ 
+-- send: Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
+-- send config responseHandler (Request req reqfuns) =
+--     runSendRequest config (RequestWithHandler req (List.reverse reqfuns) responseHandler)
 
 
-{-| Internal function that performs the specified request as a command.
--}
-runSendRequest : Config req res msg -> RequestWithHandler req res msg -> Cmd msg
-runSendRequest config request =
-    SendWithNextId request
-        |> Task.succeed
-        |> Task.perform identity
-        |> Cmd.map config.porterMsg
+-- {-| Internal function that performs the specified request as a command.
+-- -}
+-- runSendRequest : Config req res msg -> RequestWithHandler req res msg -> Cmd msg
+-- runSendRequest config request =
+--     SendWithNextId request
+--         |> Task.succeed
+--         |> Task.perform identity
+--         |> Cmd.map config.porterMsg
 
 
 {-| In theory, Elm Ints can go as high as 2^53, but it's safer in the long
@@ -220,7 +231,8 @@ update config msg (Model model) =
                             |> Maybe.withDefault ( Model model, Cmd.none )
                     )
                 |> Result.withDefault ( Model model, Cmd.none )
-
+        ResolveChain multi_request ->
+            ( Model model, Porter.Internals.multiSend config identity multi_request )
 
 {-| Internal function that chains the steps of a RequestWithHandler after one another.
 -}
@@ -244,5 +256,5 @@ handleResponse config (Model model) id res (RequestWithHandler msg mappers final
                     reqMappers
             in
                 ( Model { model | handlers = Dict.remove id model.handlers }
-                , runSendRequest config (RequestWithHandler (extractMsg request) ((extractMappers request) ++ mappers) finalResponseHandler)
+                , Porter.Internals.runSendRequest config (RequestWithHandler (extractMsg request) ((extractMappers request) ++ mappers) finalResponseHandler)
                 )

--- a/Porter.elm
+++ b/Porter.elm
@@ -24,14 +24,11 @@ module Porter
 
 @docs Model, Msg, init, update, subscriptions
 
+
 # Send messages
 
 @docs Request
 @docs request, andThen, send
-
-
-
-
 
 -}
 
@@ -39,7 +36,6 @@ import Dict exposing (Dict)
 import Task
 import Json.Encode as Encode
 import Json.Decode as Decode
-
 import Porter.Internals exposing (RequestWithHandler(..), Request(..), MultiRequest(..), Msg(..))
 
 
@@ -63,14 +59,9 @@ type Model req res msg
   - the message that porter will use for its internal communications
 
 -}
-type alias Config req res msg = Porter.Internals.Config req res msg
--- type alias Config req res msg =
---     { outgoingPort : Encode.Value -> Cmd msg
---     , incomingPort : (Encode.Value -> Msg req res msg) -> Sub (Msg req res msg)
---     , encodeRequest : req -> Encode.Value
---     , decodeResponse : Decode.Decoder res
---     , porterMsg : Msg req res msg -> msg
---     }
+type alias Config req res msg =
+    Porter.Internals.Config req res msg
+
 
 {-| Initialize model.
 -}
@@ -96,26 +87,21 @@ encode encodeReq id msg =
 
 {-| Module messages.
 -}
-type alias Msg req res msg = Porter.Internals.Msg req res msg
--- type Msg req res msg
---     = SendWithNextId (RequestWithHandler req res msg)
---     | Receive Encode.Value
---     | ResolveChain (MultiRequest req res msg)
+type alias Msg req res msg =
+    Porter.Internals.Msg req res msg
 
 
 {-| Internal type used by requests that have a response handler.
 -}
-type alias RequestWithHandler req res msg = Porter.Internals.RequestWithHandler req res msg
--- type RequestWithHandler req res msg
---     = RequestWithHandler req (List (res -> Request req res)) (res -> msg)
+type alias RequestWithHandler req res msg =
+    Porter.Internals.RequestWithHandler req res msg
 
 
 {-| Opaque type of a 'request'. Use the `request` function to create one,
 chain them using `andThen` and finally send it using `send`.
 -}
-type alias Request req res = Porter.Internals.Request req res
--- type Request req res
---     = Request req (List (res -> Request req res))
+type alias Request req res =
+    Porter.Internals.Request req res
 
 
 {-| Subscribe to messages from ports.
@@ -144,24 +130,9 @@ andThen reqfun (Request initialReq reqfuns) =
 
 {-| Sends a request earlier started using `request`.
 -}
-
-send: Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
+send : Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
 send config responseHandler request =
     Porter.Internals.send config responseHandler request
- 
--- send: Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
--- send config responseHandler (Request req reqfuns) =
---     runSendRequest config (RequestWithHandler req (List.reverse reqfuns) responseHandler)
-
-
--- {-| Internal function that performs the specified request as a command.
--- -}
--- runSendRequest : Config req res msg -> RequestWithHandler req res msg -> Cmd msg
--- runSendRequest config request =
---     SendWithNextId request
---         |> Task.succeed
---         |> Task.perform identity
---         |> Cmd.map config.porterMsg
 
 
 {-| In theory, Elm Ints can go as high as 2^53, but it's safer in the long
@@ -231,8 +202,10 @@ update config msg (Model model) =
                             |> Maybe.withDefault ( Model model, Cmd.none )
                     )
                 |> Result.withDefault ( Model model, Cmd.none )
+
         ResolveChain multi_request ->
             ( Model model, Porter.Internals.multiSend config identity multi_request )
+
 
 {-| Internal function that chains the steps of a RequestWithHandler after one another.
 -}

--- a/Porter/Internals.elm
+++ b/Porter/Internals.elm
@@ -1,0 +1,130 @@
+module Porter.Internals exposing (..)
+
+{-| Do not use this module directly!
+-}
+
+import Json.Encode as Encode
+import Json.Decode as Decode
+import Task
+
+
+{- Internal type used by requests that have a response handler. -}
+
+
+type RequestWithHandler req res msg
+    = RequestWithHandler req (List (res -> Request req res)) (res -> msg)
+
+
+
+{- Opaque type of a 'request'. Use the `request` function to create one,
+   chain them using `andThen` and finally send it using `send`.
+-}
+
+
+type Request req res
+    = Request req (List (res -> Request req res))
+
+
+type MultiRequest req res a
+    = SimpleRequest (Request req res) (res -> a)
+    | ComplexRequest (Request req res) (res -> MultiRequest req res a)
+    | ShortCircuit a
+
+
+
+{- Module messages. -}
+
+
+type Msg req res msg
+    = SendWithNextId (RequestWithHandler req res msg)
+    | Receive Encode.Value
+    | ResolveChain (MultiRequest req res msg)
+
+
+
+{- Porter configuration, containing:
+
+   - ports
+   - message encoders/decoders.
+   - the message that porter will use for its internal communications
+
+-}
+
+
+type alias Config req res msg =
+    { outgoingPort : Encode.Value -> Cmd msg
+    , incomingPort : (Encode.Value -> Msg req res msg) -> Sub (Msg req res msg)
+    , encodeRequest : req -> Encode.Value
+    , decodeResponse : Decode.Decoder res
+    , porterMsg : Msg req res msg -> msg
+    }
+
+
+
+{- Turns the request's specialized response type into a different type. -}
+
+
+multiMap : (a -> b) -> MultiRequest req res a -> MultiRequest req res b
+multiMap mapfun req =
+    case req of
+        SimpleRequest porter_req request_mapper ->
+            SimpleRequest porter_req (request_mapper >> mapfun)
+
+        ComplexRequest porter_req next_request_fun ->
+            ComplexRequest porter_req (\res -> multiMap mapfun (next_request_fun res))
+
+        ShortCircuit val ->
+            ShortCircuit (mapfun val)
+
+
+
+{- Actually sends a (chain of) request(s).
+
+   A final handler needs to be specified that turns the final result into a `msg`.
+   This `msg` will be called with the final resulting `a` once the final response has returned.
+
+-}
+
+
+multiSend : Config req res msg -> (a -> msg) -> MultiRequest req res a -> Cmd msg
+multiSend config msg_handler request =
+    let
+        mapped_request =
+            request |> multiMap msg_handler
+    in
+        case mapped_request of
+            SimpleRequest porter_req response_handler ->
+                send (config) response_handler porter_req
+
+            ComplexRequest porter_req next_request_fun ->
+                let
+                    resfun res =
+                        config.porterMsg (ResolveChain (next_request_fun res))
+                in
+                    send (config) resfun porter_req
+
+            ShortCircuit val ->
+                val
+                    |> Task.succeed
+                    |> Task.perform identity
+
+
+
+{- Sends a request earlier started using `request`. -}
+
+
+send : Config req res msg -> (res -> msg) -> Request req res -> Cmd msg
+send config responseHandler (Request req reqfuns) =
+    runSendRequest config (RequestWithHandler req (List.reverse reqfuns) responseHandler)
+
+
+
+{- Internal function that performs the specified request as a command. -}
+
+
+runSendRequest : Config req res msg -> RequestWithHandler req res msg -> Cmd msg
+runSendRequest config request =
+    SendWithNextId request
+        |> Task.succeed
+        |> Task.perform identity
+        |> Cmd.map config.porterMsg

--- a/Porter/Internals.elm
+++ b/Porter/Internals.elm
@@ -67,11 +67,11 @@ type alias Config req res msg =
 multiMap : (a -> b) -> MultiRequest req res a -> MultiRequest req res b
 multiMap mapfun req =
     case req of
-        SimpleRequest porter_req request_mapper ->
-            SimpleRequest porter_req (request_mapper >> mapfun)
+        SimpleRequest porterReq request_mapper ->
+            SimpleRequest porterReq (request_mapper >> mapfun)
 
-        ComplexRequest porter_req next_request_fun ->
-            ComplexRequest porter_req (\res -> multiMap mapfun (next_request_fun res))
+        ComplexRequest porterReq nextRequestFun ->
+            ComplexRequest porterReq (\res -> multiMap mapfun (nextRequestFun res))
 
         ShortCircuit val ->
             ShortCircuit (mapfun val)
@@ -87,21 +87,21 @@ multiMap mapfun req =
 
 
 multiSend : Config req res msg -> (a -> msg) -> MultiRequest req res a -> Cmd msg
-multiSend config msg_handler request =
+multiSend config msgHandler request =
     let
-        mapped_request =
-            request |> multiMap msg_handler
+        mappedRequest =
+            request |> multiMap msgHandler
     in
-        case mapped_request of
-            SimpleRequest porter_req response_handler ->
-                send (config) response_handler porter_req
+        case mappedRequest of
+            SimpleRequest porterReq responseHandler ->
+                send (config) responseHandler porterReq
 
-            ComplexRequest porter_req next_request_fun ->
+            ComplexRequest porterReq nextRequestFun ->
                 let
                     resfun res =
-                        config.porterMsg (ResolveChain (next_request_fun res))
+                        config.porterMsg (ResolveChain (nextRequestFun res))
                 in
-                    send (config) resfun porter_req
+                    send (config) resfun porterReq
 
             ShortCircuit val ->
                 val

--- a/Porter/Multi.elm
+++ b/Porter/Multi.elm
@@ -12,9 +12,10 @@ module Porter.Multi
         )
 
 {-| With `Porter.Multi` you can create requests that have specialized return values.
-Use this if the normal response types are not good enough for you.
 
-The setup is exactly the same as when using Porter normally; and just use the `request` and `send` commands that this module provides instead to create requests with specialized return types.
+This is an advanced usage pattern of Porter. For most use-cases, using Porter itself should be sufficient. If, however, you have a tangible issue with expressing chaining and transformations with your port messages, read along :).
+
+The setup is exactly the same as when using Porter normally. Just use the `request` and `send` commands that this module provides instead to create requests with specialized return types.
 
 Mapping over responses and chaining requests is supported.
 

--- a/Porter/Multi.elm
+++ b/Porter/Multi.elm
@@ -1,0 +1,182 @@
+module Porter.Multi
+    exposing
+        ( Request
+        , request
+        , andThen
+        , andThenResult
+        , map
+        , map2
+        , map3
+        , send
+        )
+
+{-| With `Porter.Multi` you can create requests that have specialized return values.
+Use this if the normal response types are not good enough for you.
+
+The setup is exactly the same as when using Porter normally; and just use the `request` and `send` commands that this module provides instead to create requests with specialized return types.
+
+Mapping over responses and chaining requests is supported.
+
+
+# Send Messages
+
+@docs Request
+@docs request, send
+
+
+# Chain Requests
+
+@docs andThen, andThenResult, map, map2, map3
+
+
+# Low-level Stuff
+
+@docs configToPorterConfig
+
+-}
+
+import Porter exposing (Model, Config)
+import Porter.Internals exposing (MultiRequest(..), Msg(..))
+import Result.Extra
+
+
+{-| We can either:
+
+  - Perform a single request, which will run the Porter Request and at the end turn the result into an `a`,
+  - Perform multiple requests: At the end of this request, run a function on the output that generates the next request. Note that this is set up in such a way that only the type of the final request in the chain matters.
+  - Short-circuit; just pass on the value `a` without doing any more requests.
+
+-}
+type alias Request req res a =
+    Porter.Internals.MultiRequest req res a
+
+
+
+-- type Request req res a
+-- = SimpleRequest (Porter.Request req res) (res -> a)
+-- | ComplexRequest (Porter.Request req res) (res -> Request req res a)
+-- | ShortCircuit a
+-- | To configure Porter.Multi, you'll need:
+-- 1.  An outgoingPort of the correct type
+-- 2.  An incoming port of the correct type
+-- 3.  A way to encode the request type into JSON
+-- 4.  A way to decode the response JSON into an intermediate common 'res' type.
+-- 5.  A `msg` that will be used to perform the internal chaining of requests.
+-- type alias Config req res msg =
+--     { outgoingPort : Encode.Value -> Cmd msg
+--     , incomingPort : (Encode.Value -> Porter.Msg req res msg) -> Sub (Porter.Msg req res msg)
+--     , encodeRequest : req -> Encode.Value
+--     , decodeResponse : Decode.Decoder res
+--     , porterMultiMsg : Msg req res msg -> msg
+--     }
+-- {-| Allows us to perform low-level Porter calls using the Porter.Multi configuration
+-- Unless you know what you are doing, you probably don't need this ;-)
+-- -}
+-- configToPorterConfig : Config req res msg -> Porter.Config req res msg
+-- configToPorterConfig config =
+--     { porterMsg = (\msg -> (config.porterMultiMsg (PorterMsg msg)))
+--     , outgoingPort = config.outgoingPort
+--     , incomingPort = config.incomingPort
+--     , encodeRequest = config.encodeRequest
+--     , decodeResponse = config.decodeResponse
+--     }
+-- | The internal message type. Eiher:
+--   - A low level Porter message
+--   - One step in a multi-step request chain.
+-- type alias Msg req res msg = Porter.Msg req res msg
+-- type Msg req res msg
+--     = PorterMsg (Porter.Msg req res msg)
+--     | ResolveChain (Request req res msg)
+-- | The Porter.Multi Model is used to keep track of state
+-- across one or multiple port request<->response steps.
+-- type alias Model req res msg = Porter.Model req res msg
+-- type alias Model req res msg =
+--     { porter_model : Porter.Model req res msg }
+-- | Initializes a new Porter.Multi model.
+-- Should probably be called as part of your program's `init` call.
+-- init : Model req res msg
+-- init =
+--     { porter_model = Porter.init }
+
+
+{-| Creates a new Porter.Multi request, specifying:
+
+  - the request itself in the common `req` type
+  - A response handler function tha turns the common `res` type into a specialized `a`.
+
+-}
+request : req -> (res -> a) -> Request req res a
+request req response_handler =
+    SimpleRequest (Porter.request req) response_handler
+
+
+{-| Combines together multiple Porter.Multi requests
+-}
+andThen : (a -> Request req res b) -> Request req res a -> Request req res b
+andThen reqfun req =
+    case req of
+        SimpleRequest porter_req request_mapper ->
+            ComplexRequest (porter_req) (request_mapper >> reqfun)
+
+        ComplexRequest porter_req next_request_fun ->
+            ComplexRequest porter_req (\res -> andThen reqfun (next_request_fun res))
+
+        ShortCircuit val ->
+            reqfun val
+
+
+{-| andThenResult function similar to `andThen`,
+but will short-circuit the request/response chain once an `Err val` is received.
+
+Working with Result-objects is very common, since the specialising of `res -> a` (that you pass to `request`) is usually an operation that might fail (like a Decoder)
+
+-}
+andThenResult : (a -> Request req res (Result err b)) -> Request req res (Result err a) -> Request req res (Result err b)
+andThenResult reqfun req =
+    case req of
+        ShortCircuit (Err val) ->
+            ShortCircuit (Err val)
+
+        ShortCircuit (Ok val) ->
+            (reqfun val)
+
+        SimpleRequest porter_req request_mapper ->
+            ComplexRequest (porter_req)
+                (request_mapper >> Result.Extra.unpack (ShortCircuit << Err) (reqfun))
+
+        ComplexRequest porter_req next_request_fun ->
+            ComplexRequest porter_req (\res -> andThenResult reqfun (next_request_fun res))
+
+
+{-| Turns the request's specialized response type into a different type.
+-}
+map : (a -> b) -> Request req res a -> Request req res b
+map mapfun req =
+    Porter.Internals.multiMap mapfun req
+
+
+{-| Chains two requests, and then combines their two responses into one new `c`.
+-}
+map2 : (a -> b -> c) -> Request req res a -> Request req res b -> Request req res c
+map2 mapfun req_a req_b =
+    req_a
+        |> andThen (\res_a -> req_b |> map (mapfun res_a))
+
+
+{-| Chains three requests, and then combines their three responses into one new `c`.
+-}
+map3 : (a -> b -> c -> d) -> Request req res a -> Request req res b -> Request req res c -> Request req res d
+map3 mapfun req_a req_b req_c =
+    req_a
+        |> andThen (\res_a -> map2 (mapfun res_a) req_b req_c)
+
+
+{-| Actually sends a (chain of) request(s).
+
+A final handler needs to be specified that turns the final result into a `msg`.
+This `msg` will be called with the final resulting `a` once the final response has returned.
+
+-}
+send : Config req res msg -> (a -> msg) -> Request req res a -> Cmd msg
+send config msg_handler request =
+    Porter.Internals.multiSend config msg_handler request

--- a/Porter/Multi.elm
+++ b/Porter/Multi.elm
@@ -2,6 +2,7 @@ module Porter.Multi
     exposing
         ( Request
         , request
+        , fromSimple
         , andThen
         , andThenResult
         , map
@@ -22,6 +23,7 @@ Mapping over responses and chaining requests is supported.
 
 @docs Request
 @docs request, send
+@docs fromSimple
 
 
 # Chain Requests
@@ -60,6 +62,13 @@ type alias Request req res a =
 request : req -> (res -> a) -> Request req res a
 request req responseHandler =
     SimpleRequest (Porter.request req) responseHandler
+
+
+{-| Turns a simple Porter request into a Porter.Multi request
+-}
+fromSimple : Porter.Request req res -> Request req res res
+fromSimple request =
+    SimpleRequest request identity
 
 
 {-| Combines together multiple Porter.Multi requests


### PR DESCRIPTION
This PR adds the `Porter.Multi` module that allows using requests with specialized response types.

Note that I've had to split off some functionality to a `Porter.Internals` module to prevent dependency cycles. I am not very happy that these things are theoretically visible to the user (The `Porter.Internals` module has to expose them for the other two modules to use it). If you know a way to improve this, that would be nice.

**EDIT**: I now know that as long as you do not add a module to the `exposed-modules` of the package information, it will not be visible outside the package. So this is not a problem at all! :smile: 

- [x] Porter.Multi basic functionality of specialized return types
- [x] Porter.Multi.andThen chaining
- [x] Porter.Multi.map, map2, map3
- [x] Making sure old Porter setup is enough to use the new library (adding a new type variant to Porter.Msg and a new clause to the `update` function to match).
- [x] Altering the casing of variable names (which is the method I use) to dromedarisCase (which is what Porter, i.e. @peterszerzo  uses).
- [x] A `Porter.Multi.fromSimple` call that turns a normal `Porter.Request` into a `Porter.Multi.Request`
- [ ] example code that uses `Porter.Multi`
