### PR TITLE
Fix `Porter.Multi` so it can be published

### DIFF
--- a/Porter/Internals.elm
+++ b/Porter/Internals.elm
@@ -8,6 +8,20 @@ import Json.Decode as Decode
 import Task
 
 
+{- Utilities -}
+
+
+unpackResult : (e -> b) -> (a -> b) -> Result e a -> b
+unpackResult mapError mapSuccess res =
+    case res of
+        Ok successValue ->
+            mapSuccess successValue
+
+        Err errorValue ->
+            mapError errorValue
+
+
+
 {- Internal type used by requests that have a response handler. -}
 
 

--- a/Porter/Multi.elm
+++ b/Porter/Multi.elm
@@ -31,16 +31,10 @@ Mapping over responses and chaining requests is supported.
 
 @docs andThen, andThenResult, map, map2, map3
 
-
-# Low-level Stuff
-
-@docs configToPorterConfig
-
 -}
 
 import Porter exposing (Model, Config)
-import Porter.Internals exposing (MultiRequest(..), Msg(..))
-import Result.Extra
+import Porter.Internals exposing (MultiRequest(..), Msg(..), unpackResult)
 
 
 {-| We can either:
@@ -104,7 +98,7 @@ andThenResult reqfun req =
 
         SimpleRequest porterReq requestMapper ->
             ComplexRequest (porterReq)
-                (requestMapper >> Result.Extra.unpack (ShortCircuit << Err) (reqfun))
+                (requestMapper >> unpackResult (ShortCircuit << Err) (reqfun))
 
         ComplexRequest porterReq nextRequestFun ->
             ComplexRequest porterReq (\res -> andThenResult reqfun (nextRequestFun res))

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "summary": "Elm ports' wrapper for uncomplicated request-response-style communication",
     "repository": "https://github.com/peterszerzo/elm-porter.git",
     "license": "BSD3",
@@ -7,7 +7,8 @@
         "."
     ],
     "exposed-modules": [
-        "Porter"
+        "Porter",
+        "Porter.Multi"
     ],
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0"


### PR DESCRIPTION
This PR adds `Porter.Multi` to exposed modules, and fixes a few publishing-related issues.